### PR TITLE
Add 'sku' field to refund data in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ public function refundPayment(Request $request)
         'trx_id'     => $request->input('trx_id'),
         'amount'     => $request->input('amount'),
         'reason'     => $request->input('reason'),
+        'sku'        => $request->input('sku'),
     ];
 
     try {


### PR DESCRIPTION
The SKU field is required to perform the refund process successfully. If the SKU field is missing, bKash returns an 'Invalid SKU' error.

`
{
    "success": false,
    "message": "Invalid SKU"
}
`